### PR TITLE
ボタン動作変更

### DIFF
--- a/front/components/top/buttonItem.vue
+++ b/front/components/top/buttonItem.vue
@@ -95,7 +95,7 @@ export default {
 }
 
 .ButtonTextContainer:hover{
-  transform: scale(1.1);
+  transform: scale(1.1) translate(-12px ,-12px);
 }
 
 .buttonText {


### PR DESCRIPTION
ホバー前はbackground(赤色)が隠れててホバー時にbackgroundも飛び出す仕様も考えましたが、backgroundが隠れているホバー前の画面が少しチープに見えたので赤背景はホバー前も見せることにしました。今回はホバー時にテキストコンテナが少し斜め上に動く動作を加えました。