### PR TITLE
fix:拡張子揃え

### DIFF
--- a/front/components/kikaku/index.vue
+++ b/front/components/kikaku/index.vue
@@ -31,27 +31,27 @@
     </div>
 
     <div class="kikakuItemList">
-        <item kikakuID="1" title="ゆかたコンテスト" imgUrl="/img/kikaku/yukacon.jpg" holder="一年生・有志" :places="['メインステージ']":dates="['5月30日：18:30～19:30']"
+        <item kikakuID="1" title="ゆかたコンテスト" imgUrl="/img/kikaku/yukacon.JPG" holder="一年生・有志" :places="['メインステージ']":dates="['5月30日：18:30～19:30']"
             description="やどかり祭を最高に盛り上げるメイン企画。各チームが個性的なパフォーマンスで観客の皆さんを魅了し優勝を目指します。ゆかたを着た出演者を中心としたチーム一丸となってのパフォーマンスは必見です。" />
-        <item kikakuID="2" title="火文字前パフォ・火文字" imgUrl="/img/kikaku/himoji.jpg" holder="全体装飾部局" :places="['みらしゃか前']" :dates='["5月29日：21:05～21:30"]'
+        <item kikakuID="2" title="火文字前パフォ・火文字" imgUrl="/img/kikaku/himoji.JPG" holder="全体装飾部局" :places="['みらしゃか前']" :dates='["5月29日：21:05～21:30"]'
             description="委員による幻想的な火文字。例年漢字一文字に火を灯しますが、今年は何になるのでしょうか。そしてその直前に行われる筑波大学の団体によるパフォーマンスも見逃せません。" />
-        <item kikakuID="3" title="野外ライブ" imgUrl="/img/kikaku/live.jpg" holder="有志・サークル" :places="['メインステージ']" :dates='["5月29日：16:00～20:40"]'
+        <item kikakuID="3" title="野外ライブ" imgUrl="/img/kikaku/live.JPG" holder="有志・サークル" :places="['メインステージ']" :dates='["5月29日：16:00～20:40"]'
             description="筑波大学のバンドサークルから出演者を集めて、ライブパフォーマンスを行ってもらう前夜祭の激アツ企画です。皆様が楽しめること間違いなしです。ぜひご来場ください。" />
-        <item kikakuID="4" title="御輿" imgUrl="/img/kikaku/mikosi.jpg" holder="一年生" :places="['みらしゃか前','メインストリート']" :dates='["5月30日：16:50～18:00"]'
+        <item kikakuID="4" title="御輿" imgUrl="/img/kikaku/mikosi.JPG" holder="一年生" :places="['みらしゃか前','メインストリート']" :dates='["5月30日：16:50～18:00"]'
             description="祭といえば、やっぱり御輿。御輿が会場のメインストリートを縦断する迫力満点の練り歩きと趣向を凝らしたパフォーマンスは必見です。" />
-        <item kikakuID="5" title="やどかりダンス" imgUrl="/img/kikaku/dance.jpg" holder="有志・サークル" :places="['メインステージ']" :dates='["5月30日：12:50～15:35"]'
+        <item kikakuID="5" title="やどかりダンス" imgUrl="/img/kikaku/dance.JPG" holder="有志・サークル" :places="['メインステージ']" :dates='["5月30日：12:50～15:35"]'
             description="筑波大学のダンス系サークルや部活がパフォーマンスをする企画です。それぞれの団体が独自のパフォーマンスを通じて表現し、団体それぞれに違った色をみることができます。ぜひ会場まで足を運んでみてください。" />
-        <item kikakuID="6" title="ミニステージパフォーマンス" imgUrl="/img/kikaku/stage.jpg" holder="有志・サークル" :places="['平砂宿舎4・6号棟間']" 
+        <item kikakuID="6" title="ミニステージパフォーマンス" imgUrl="/img/kikaku/stage.JPG" holder="有志・サークル" :places="['平砂宿舎4・6号棟間']" 
             :dates='["5月29日：18:00～20:00","5月30日：12:00～16:15"]'
             description="筑波大学の団体がミニステージで演奏・パフォーマンスをする企画です。お気軽にお立ち寄りください。" />
-        <item kikakuID="7" title="ストリートパフォーマンス" imgUrl="/img/kikaku/street.jpg" holder="有志・サークル" :places="['みらしゃか前交差点']" 
+        <item kikakuID="7" title="ストリートパフォーマンス" imgUrl="/img/kikaku/street.JPG" holder="有志・サークル" :places="['みらしゃか前交差点']" 
             :dates='["5月30日：13:00～15:30"]'
             description="筑波大学の団体がストリート上で演奏・パフォーマンスをする企画です。お気軽にお立ち寄りください。" />
         <item kikakuID="8" title="やどカラ" imgUrl="/img/kikaku/noImg.jpg" holder="有志" :places="['みらしゃか前']" :dates='["5月30日：14:30～16:40"]'
             description="やどカラ！参加者が歌を歌ってその出来を競う企画です。御輿の前にやどカラを見て気持ちを盛り上げましょう。" />
-        <item kikakuID="9" title="縁日" imgUrl="/img/kikaku/enniti.jpg" holder="企画部局" :places="['メインステージ横']"  :dates='["5月29日：17:00～18:30","5月30日：11:10～16:20,18:10～20:30"]'
+        <item kikakuID="9" title="縁日" imgUrl="/img/kikaku/enniti.JPG" holder="企画部局" :places="['メインステージ横']"  :dates='["5月29日：17:00～18:30","5月30日：11:10～16:20,18:10～20:30"]'
             description="縁日は巨大だるま落としや、射的などで遊べる企画です。お祭りらしいエリアになっているのでぜひ楽しんでいってください。" />
-        <item kikakuID="10" title="本祭OP" imgUrl="/img/kikaku/OP.jpg" holder="有志・サークル" :places="['メインステージ']"  :dates='["5月30日：11:10～12:05"]'
+        <item kikakuID="10" title="本祭OP" imgUrl="/img/kikaku/OP.JPG" holder="有志・サークル" :places="['メインステージ']"  :dates='["5月30日：11:10～12:05"]'
             description="本祭オープニングでは筑波大学のサークルがやどかり祭本祭の開幕を盛り上げてくれます。みんなで祭の開幕をむかえましょう。" />
         <item kikakuID="11" title="表彰式・花火打ち上げ" imgUrl="/img/kikaku/noImg.jpg" holder="実行委員" :places="['メインステージ']" :dates='["5月30日：19:40～21:00"]'
             description="やどかり祭本祭のフィナーレを飾る表彰式。ゆかたコンテストの優勝チームがここで発表されます。そして祭の締めくくりとして、20:50からは打ち上げ花火が平砂の夜空を彩ります。感動のクライマックスをぜひ最後までご覧ください。" />


### PR DESCRIPTION
Netlify: CDNレイヤーでURLの大文字小文字を吸収する動作があるため、OP.jpgでリクエストしても実際のOP.JPGを返せていた。

Cloudflare Pages: ファイルをそのままLinuxのケースセンシティブなファイルシステムで提供するため、OP.jpgでリクエストするとOP.JPGが見つからず404になる。

つまり同じLinuxサーバーでも、NetlifyはCDNが間に入ってケースを補正していたのに対し、Cloudflare Pagesはより素直にファイルシステムに従うという違いです。今回の修正で解消されます。

↑claude
上記の理由で小文字大文字拡張子を互換できないらしい

のでurl指定をそれぞれの画像の拡張子に合わせた